### PR TITLE
Fix chapter 12

### DIFF
--- a/chapter12/README.md
+++ b/chapter12/README.md
@@ -1,6 +1,6 @@
-## Chapter 6: Outputting Data
+## Chapter 12: HATEOAS
 
-This is sample code for Chapter 6 of the book [Build APIs You Won't Hate][].
+This is sample code for Chapter 12 of the book [Build APIs You Won't Hate][].
 
     $ php artisan migrate
     $ php artisan db:seed

--- a/chapter12/app/routes.php
+++ b/chapter12/app/routes.php
@@ -13,7 +13,7 @@
 
 Route::get('/users', 'UserController@index');
 Route::get('/users/{id}', 'UserController@show');
-Route::get('/users/{id}/checkins', 'UserController@checkins');
+Route::get('/users/{id}/checkins', 'UserController@getCheckins');
 
 Route::get('/places', 'PlaceController@index');
 Route::get('/places/{id}', 'PlaceController@show');


### PR DESCRIPTION
Updated chapter 12's route file to use the method in the controller and updated the README to reflect which chapter we're actually in.

@philsturgeon There are some other issues in the README, notably that `composer install` isn't included in the directions, `./run-demo.sh` isn't in the directory, and browsing to the URL listed won't work because this is the HATEOAS chapter and you'll get an error about MIME types unless you want to delve into editing requests. I'm happy to fix all of these but I'd like to know:

- Is it worth adding ALL of the setup instructions here or is `composer install` and the like implied at this point?
- Would you prefer to have a run-demo script or to remove this line in favor of `php artisan serve`?
- Should the instructions about opening a browser be replaced with a curl command?